### PR TITLE
Update StripeV3 driver to use default product name

### DIFF
--- a/src/Services/Drivers/StripeV3.php
+++ b/src/Services/Drivers/StripeV3.php
@@ -23,7 +23,7 @@ class StripeV3 extends Driver
                         'unit_amount' => round($payment->amount + $payment->charge, 2) * 100,
                         'currency' => "$payment->method_currency",
                         'product_data' => [
-                            'name' => setting('site_name'),
+                            'name' => setting('site_name', config('app.name', 'Default Product Name')),
                             'description' => 'Payment with Stripe',
                         ]
                     ],

--- a/src/Services/Drivers/StripeV3.php
+++ b/src/Services/Drivers/StripeV3.php
@@ -23,7 +23,7 @@ class StripeV3 extends Driver
                         'unit_amount' => round($payment->amount + $payment->charge, 2) * 100,
                         'currency' => "$payment->method_currency",
                         'product_data' => [
-                            'name' => setting('site_name', config('app.name', 'Default Product Name')),
+                            'name' => config('app.name', 'Default Product Name'),
                             'description' => 'Payment with Stripe',
                         ]
                     ],


### PR DESCRIPTION
Resolves: Issue https://github.com/tomatophp/filament-payments/issues/7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced product name retrieval for Stripe transactions by adding a default value, improving consistency in payment processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->